### PR TITLE
Do not include fields with nil values in datapoint

### DIFF
--- a/lib/influx/datapoints.ex
+++ b/lib/influx/datapoints.ex
@@ -197,10 +197,18 @@ defmodule Influx.Datapoints do
   defp parse_seria(seria) do
     name = seria["name"]
     keys = seria["columns"]
-    key_values_map = Enum.map(seria["values"],
-                              &(Enum.zip(keys, &1) |> Enum.into(%{})))
+    list_of_maps =
+      Enum.map(seria["values"],
+               fn values -> keys_and_values_to_map(keys, values) end)
     %{"name" => name,
-      "data" => key_values_map}
+      "data" => list_of_maps}
+  end
+
+  @spec keys_and_values_to_map([term], [term]) :: [map]
+  defp keys_and_values_to_map(keys, values) do
+    Enum.zip(keys, values)
+    |> Enum.filter( fn {_, v} -> v != nil end)
+    |> Enum.into(%{})
   end
 
   @spec make_datapoints_values([String.t], [[integer]]) :: [[integer]]


### PR DESCRIPTION
We may have situation like:

```
Time    X       Y       Z
  1 .   nil     nil      0
  2 .    1      nil      0
  3 .    1      nil      0
```

So in this situation we want to get rid of all Y values and X value for 1st metric. In library representation it would look like this:
```
%{"name" => "some_measurement",
    "data" => [
      %{"Z" => 0, "time" => 1},
      %{"X" => 1, "Z" => 0, "time" => 2},
      %{"X" => 1, "Z" => 0, "time" => 3},
   ]
}
```