### PR TITLE
Accept nil values and cast them to 0

### DIFF
--- a/lib/flex/datapoints.ex
+++ b/lib/flex/datapoints.ex
@@ -186,6 +186,7 @@ defmodule Flex.Datapoints do
   defp do_escape_field(value, _) when is_float(value) or is_boolean(value),
     do: "#{value}"
   defp do_escape_field(value, _) when is_binary(value), do: "\"#{value}\""
+  defp do_escape_field(nil, _), do: "0"
 
   ###
   # Private functions


### PR DESCRIPTION
This solution worked for my case: i.e. when we kill a running MongooseIM node and then transfer metrics there's no error. Grafana correctly displays the graphs where the values are simply cut off (it's not displaying 0 though).

Previously we'd get the following error:
```elixir
error] Process #PID<0.2128.0> raised an exception
  ** (FunctionClauseError) no function clause matching in Flex.Datapoints.do_escape_field/2
    (flex) lib/flex/datapoints.ex:180: Flex.Datapoints.do_escape_field(nil, :int_to_float)
    (flex) lib/flex/datapoints.ex:260: anonymous fn/2 in Flex.Datapoints.tuples_to_line/3
    (elixir) lib/enum.ex:1294: Enum."-map/2-lists^map/1-0-"/2
    (flex) lib/flex/datapoints.ex:260: Flex.Datapoints.tuples_to_line/3
    (flex) lib/flex/datapoints.ex:240: Flex.Datapoints.make_line_protocol/5
    (elixir) lib/enum.ex:1294: Enum."-map/2-lists^map/1-0-"/2
    (elixir) lib/stream.ex:444: anonymous fn/3 in Stream.flat_map/2
    (elixir) lib/stream.ex:867: Stream.do_transform_user/6
    (elixir) lib/stream.ex:1536: Enumerable.Stream.do_each/4
    (elixir) lib/enum.ex:1911: Enum.map/2
    (tide) lib/tide/influx.ex:66: Tide.Influx.dump_data/3
    (elixir) lib/enum.ex:1294: Enum."-map/2-lists^map/1-0-"/2
    (tide) lib/tide/clt/env/swarm/dc.ex:6: anonymous fn/1 in Tide.CLT.Env.Swarm.DC.dump_db/1
```